### PR TITLE
Correção model.extrato e repository.extrato

### DIFF
--- a/src/main/java/br/com/accentbank/accentBank/model/Extrato.java
+++ b/src/main/java/br/com/accentbank/accentBank/model/Extrato.java
@@ -1,5 +1,19 @@
 package br.com.accentbank.accentBank.model;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
 public class Extrato {
+	@Id
+	Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
 
 }

--- a/src/main/java/br/com/accentbank/accentBank/service/ExtratoService.java
+++ b/src/main/java/br/com/accentbank/accentBank/service/ExtratoService.java
@@ -13,6 +13,8 @@ public class ExtratoService {
 	@Autowired
 	ExtratoRepository repository;
 	
+	
+	
 	public void saveExtrato(Extrato extrato) {
 		
 		repository.save(extrato);


### PR DESCRIPTION
A dependência do JPA precisou que o model extrato fosse anotado com entidade (@Entity) e tivesse o atributo id também com a anotação (@Id).